### PR TITLE
Support for additional webdrivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ First, you need a WebDriver for your browser of choice:
 - **Chrome**: https://chromedriver.chromium.org/
 - **Firefox**: https://github.com/mozilla/geckodriver
 - **Edge**: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
-- **IE**: https://www.selenium.dev/downloads/
 - **Opera**: https://github.com/operasoftware/operachromiumdriver
 - **Safari**: https://developer.apple.com/documentation/webkit/testing_with_webdriver_in_safari
 
@@ -34,7 +33,7 @@ Then, install all dependencies with pip:
 \
 A test for a specific web page can then be executed with the following command:
 
-    python vat.py [OPTION] WEBPAGE
+    python vat.py [OPTIONS] WEBPAGE
 
 For help, run:
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,17 @@ A Python script to test a web page for six testing criteria regarding visual acc
 
 ## How to run
 
-First, you need ChromeDriver:
+First, you need a WebDriver for your browser of choice:
+- **Chrome**: https://chromedriver.chromium.org/
+- **Firefox**: https://github.com/mozilla/geckodriver
+- **Edge**: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
+- **IE**: https://www.selenium.dev/downloads/
+- **Opera**: https://github.com/operasoftware/operachromiumdriver
+- **Safari**: https://developer.apple.com/documentation/webkit/testing_with_webdriver_in_safari
 
-    https://chromedriver.chromium.org/ (Make sure that the selected ChromeDriver version matches your current Chrome version)
+(Make sure that the selected WebDriver version matches your current browser version)
 
-The path to your chromedriver.exe must be in your PATH.
+The path to the webdriver must be in your PATH.
 
 \
 Then, install all dependencies with pip:
@@ -28,6 +34,10 @@ Then, install all dependencies with pip:
 \
 A test for a specific web page can then be executed with the following command:
 
-    python vat.py <url> <required accessibility level>
+    python vat.py [OPTION] WEBPAGE
+
+For help, run:
+
+    python vat.py --help
 
 The required accessibility level is a value between 0 and 1. It is compared with the actual accessibility level that is achieved in the test, which is calculated by dividing the successful checks through the total number of executed checks. If the achieved accessibility level is equal to or higher than the required accessibility level, the program will return an exit code of 0, otherwise an exit code of 1 will be returned.

--- a/vat.py
+++ b/vat.py
@@ -273,7 +273,7 @@ def main():
         usage = "%(prog)s [OPTION] WEBPAGE",
         description = "A command line tool to test webpages for accessibility")
     parser.add_argument('webpage', help = "the webpage for which the test should be run")
-    parser.add_argument("-l", "--level", type=float, help = "the required accessibility level as a number between 0 and 1 with 1 not allowing any failures", required = False, default = 1.0)
+    parser.add_argument("-l", "--level", type=float, help = "the required accessibility level as a number between 0 and 1 with 1 not allowing any failures, default is 1", required = False, default = 1.0)
     parser.add_argument("-d", "--driver", type=str, help = "the driver to use for testing (possible values: Chrome, Firefox, Edge, IE, Opera, Safari), default is Chrome", required = False, default = "Chrome")
     
     argument = parser.parse_args()

--- a/vat.py
+++ b/vat.py
@@ -1,7 +1,10 @@
 from bs4 import BeautifulSoup, Comment, Doctype
 from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
+from selenium.webdriver.edge.options import Options as EdgeOptions
+from selenium.webdriver.opera.options import Options as OperaOptions
+from selenium.webdriver.safari.options import Options as SafariOptions
 import time
 import sys
 import validators
@@ -12,10 +15,11 @@ import argparse
 from pathlib import Path
 
 class VAT:
-    def __init__(self, url, required_degree=0, chosen_driver="Chrome"):
+    def __init__(self, url, required_degree=0, chosen_driver="chrome", headless=True):
         self.url = url
         self.required_degree = required_degree
         self.chosen_driver = chosen_driver
+        self.headless = headless
         self.correct = {"doc_language":0, "alt_texts":0, "input_labels":0, "empty_buttons":0, "empty_links":0, "color_contrast":0}
         self.wrong = {"doc_language":0, "alt_texts":0, "input_labels":0, "empty_buttons":0, "empty_links":0, "color_contrast":0}
 
@@ -24,29 +28,40 @@ class VAT:
 
     def start_driver(self):
 
-        if self.chosen_driver == "Firefox":
+        if self.chosen_driver == "chrome":
+            options = ChromeOptions()
+            options.headless = self.headless
+            options.add_argument("--log-level=3")
+
+            self.driver = webdriver.Chrome(options=options)
+        elif self.chosen_driver == "firefox":
             options = FirefoxOptions()
-            options.headless = True
+            options.headless = self.headless
             options.add_argument("--log-level=3")
 
             self.driver = webdriver.Firefox(options=options)
-        else:
-            options = Options()
-            options.headless = True
+        elif self.chosen_driver == "edge":
+            options = EdgeOptions()
+            options.use_chromium = True
+            options.headless = self.headless
             options.add_argument("--log-level=3")
 
-            if self.chosen_driver == "Chrome":
-                self.driver = webdriver.Chrome(options=options)
-            elif self.chosen_driver == "Edge":
-                self.driver = webdriver.Edge(options=options)
-            elif self.chosen_driver == "IE":
-                self.driver = webdriver.Ie(options=options)
-            elif self.chosen_driver == "Opera":
-                self.driver = webdriver.Opera(options=options)
-            elif self.chosen_driver == "Safari":
-                self.driver = webdriver.Safari(options=options)
-            else:
-                raise Exception("Webdriver must be one of: Chrome, Firefox, Edge, IE, Opera, Safari")
+            self.driver = webdriver.Edge(options=options)
+        elif self.chosen_driver == "opera":
+            options = OperaOptions()
+            options.headless = self.headless
+            options.add_argument("--log-level=3")
+            options.add_experimental_option('w3c', True)
+
+            self.driver = webdriver.Opera(options=options)
+        elif self.chosen_driver == "safari":
+            options = SafariOptions()
+            options.headless = self.headless
+            options.add_argument("--log-level=3")
+
+            self.driver = webdriver.Safari(options=options)
+        else:
+            raise Exception("Webdriver must be one of: Chrome, Firefox, Edge, Opera, Safari")
 
         self.driver.set_window_size(1980, 1080)
         self.driver.get(self.url)
@@ -216,6 +231,9 @@ class VAT:
             element_visible = selenium_element.value_of_css_property('display')
             if not element_visible == "none" and (not text.name == "input" or (text.name == "input" and "type" in text.attrs and not text['type'] == "hidden")):
                 text_color = selenium_element.value_of_css_property('color')
+                if text_color[:4] != "rgba":
+                    rgba_tuple = eval(text_color[3:]) + (0,)
+                    text_color = "rgba" + str(rgba_tuple)
                 background_color = get_background_color(self.driver, text)
 
                 # calculate contrast between text color and background color
@@ -272,15 +290,17 @@ def main():
     parser = argparse.ArgumentParser(
         usage = "%(prog)s [OPTION] WEBPAGE",
         description = "A command line tool to test webpages for accessibility")
-    parser.add_argument('webpage', help = "the webpage for which the test should be run")
+    parser.add_argument("webpage", help = "the webpage for which the test should be run")
     parser.add_argument("-l", "--level", type=float, help = "the required accessibility level as a number between 0 and 1 with 1 not allowing any failures, default is 1", required = False, default = 1.0)
-    parser.add_argument("-d", "--driver", type=str, help = "the driver to use for testing (possible values: Chrome, Firefox, Edge, IE, Opera, Safari), default is Chrome", required = False, default = "Chrome")
+    parser.add_argument("-d", "--driver", type=str, help = "the driver to use for testing (possible values: Chrome, Firefox, Edge, Opera, Safari), default is Chrome", required = False, default = "Chrome")
+    parser.add_argument("--headless", help = "defines if the webdriver should run in headless mode or not", required = False, action = "store_true")
     
     argument = parser.parse_args()
 
     url = argument.webpage
     required_degree = argument.level
-    driver = argument.driver
+    driver = str(argument.driver).lower()
+    run_headless = argument.headless
 
     if not validators.url(url):
         raise Exception("Invalid URL")
@@ -288,10 +308,10 @@ def main():
     if not 0 <= required_degree <= 1:
         raise Exception("Accessibility level must be between 0 and 1")
 
-    if not driver in ["Chrome", "Firefox", "Edge", "IE", "Opera", "Safari"]:
-        raise Exception("Webdriver must be one of: Chrome, Firefox, Edge, IE, Opera, Safari")
+    if not driver in ["chrome", "firefox", "edge", "opera", "safari"]:
+        raise Exception("Webdriver must be one of: Chrome, Firefox, Edge, Opera, Safari")
 
-    vat = VAT(url, required_degree, driver)
+    vat = VAT(url, required_degree, driver, run_headless)
 
     vat.start_driver()
 
@@ -354,8 +374,12 @@ def get_background_color(driver, text):
         return "rgba(255,255,255,1)"
     selenium_element = driver.find_element(by="xpath", value=xpath_soup(text))
     background_color = selenium_element.value_of_css_property('background-color')
-    if eval(background_color[4:])[3] == 0:
-        background_color = get_background_color(driver, text.parent)
+    if background_color[:4] == "rgba":
+        if eval(background_color[4:])[3] == 0:
+            return get_background_color(driver, text.parent)
+    else:
+        rgba_tuple = eval(background_color[3:]) + (0,)
+        return "rgba" + str(rgba_tuple)
     
     return background_color
 


### PR DESCRIPTION
This Pull Request adds support for Firefox, Edge, Opera and Safari webdrivers. The Safari support has not been tested though. It also adds the possibility to not set the required accessibility level (will default to 1) and switch betwenn headless and non-headless mode via command line arguments.